### PR TITLE
Add chatx

### DIFF
--- a/firebase/__test__/chatRules.js
+++ b/firebase/__test__/chatRules.js
@@ -1,0 +1,84 @@
+import test from 'ava'
+import chai from 'chai'
+import targaryen from 'targaryen'
+import { generate } from 'firebase-bolt'
+import { readFileSync } from 'fs'
+import { database } from 'firebase'
+
+// configure targaryen
+chai.use(targaryen.chai)
+const expect = chai.expect
+const users = targaryen.users
+// add some fake users
+users.Alex = {uid: 'XXd5r6CyNZf4roaLBgzFzcwJfRZ2'}
+users.Jonh = {uid: 'YYd5r6CyNZf4roaLBgzFzcwJfRZ2'}
+
+const rulesPath = '../rules.bolt'
+
+
+test.beforeEach(t => {
+  targaryen.setFirebaseData(require('./data.json'));
+  const rules = generate(readFileSync('../rules.bolt', encoding='utf-8'))
+  targaryen.setFirebaseRules(rules);
+});
+
+test('read rooms', t => {
+    expect(users.unauthenticated).can.read.path('/rooms')
+})
+
+test('create room', t => {
+  const newRoom = {name: 'New Room', createdAt: database.ServerValue.TIMESTAMP}
+
+  expect(users.unauthenticated).cannot
+    .write(newRoom)
+    .to.path('/rooms/854edcd0-7a62-11e6-8b77-86f30ca893d3')
+  expect(users.password).can
+    .write(newRoom)
+    .to.path('/rooms/854edcd0-7a62-11e6-8b77-86f30ca893d3')
+})
+
+test('read room members', t => {
+  expect(users.unauthenticated).can.read
+    .path('/rooms-members/854ecee8-7a62-11e6-8b77-86f30ca893d3')
+})
+
+test('add myself as a room member', t => {
+  expect(users.Jonh).can
+    .write({joinedAt: database.ServerValue.TIMESTAMP})
+    .to.path('/rooms-members/854ecee8-7a62-11e6-8b77-86f30ca893d3/YYd5r6CyNZf4roaLBgzFzcwJfRZ2')
+
+    // can't add somebody else
+    expect(users.Alex).cannot
+      .write({joinedAt: database.ServerValue.TIMESTAMP})
+      .to.path('/rooms-members/854ecee8-7a62-11e6-8b77-86f30ca893d3/YYd5r6CyNZf4roaLBgzFzcwJfRZ2')
+})
+
+test('read room messages', t => {
+  expect(users.Alex).can.read
+    .path('/rooms-messages/854ecee8-7a62-11e6-8b77-86f30ca893d3')
+
+  // Jonh is not part of the room
+  expect(users.Jonh).cannot.read
+    .path('/rooms-messages/854ecee8-7a62-11e6-8b77-86f30ca893d3')
+})
+
+
+test('write messages to the room', t => {
+  const message = {
+    user: {
+      displayName: 'Alex',
+      id: 'XXd5r6CyNZf4roaLBgzFzcwJfRZ2',
+      photoURL: 'none',
+    },
+    message: 'Hi again!',
+    sentAt: database.ServerValue.TIMESTAMP
+  }
+  expect(users.Alex).can
+    .write(message)
+    .to.path('/rooms-messages/854ecee8-7a62-11e6-8b77-86f30ca893d3/f1aff870-7a6a-11e6-8b77-86f30ca893d3')
+
+    // Jonh is not room member
+    expect(users.Jonh).cannot
+      .write(message)
+      .to.path('/rooms-messages/854ecee8-7a62-11e6-8b77-86f30ca893d3/f1aff870-7a6a-11e6-8b77-86f30ca893d3')
+})

--- a/firebase/__test__/data.json
+++ b/firebase/__test__/data.json
@@ -1,0 +1,27 @@
+{
+  "rooms": {
+    "854ecee8-7a62-11e6-8b77-86f30ca893d3": {
+      "name": "Tavern",
+      "createdAt": 1473847488
+    }
+  },
+  "rooms-members": {
+    "854ecee8-7a62-11e6-8b77-86f30ca893d3": {
+      "XXd5r6CyNZf4roaLBgzFzcwJfRZ2": {
+        "joinedAt": 1473847488
+      }
+    }
+  },
+  "rooms-messages": {
+    "854ecee8-7a62-11e6-8b77-86f30ca893d3": {
+      "854ed776-7a62-11e6-8b77-86f30ca893d3": {
+        "user": {
+          "id": "XXd5r6CyNZf4roaLBgzFzcwJfRZ2",
+          "displayName": "Alex"
+        },
+        "message": "Hello here!",
+        "sentAt": 1473847488
+      }
+    }
+  }
+}

--- a/firebase/rules.bolt
+++ b/firebase/rules.bolt
@@ -74,7 +74,7 @@ type RoomMemberShip {
 
 type RoomMessage {
   user: User,
-  message: ExtraLongRequiredString,
+  text: ExtraLongRequiredString,
   sentAt:  CurrentTimestamp
 }
 

--- a/firebase/rules.bolt
+++ b/firebase/rules.bolt
@@ -6,12 +6,15 @@
 isSignedIn() { auth != null }
 isViewer(uid) { isSignedIn() && auth.uid == uid }
 isFriend(uid) { true } // We can limit access to sensitive data easily.
+isRoomMember(room_id) { isSignedIn() && prior(root['rooms-members'][room_id][auth.uid]) != null }
 
 // Types
 
 // github.com/firebase/bolt/blob/master/docs/guide.md#dealing-with-timestamps
 type CurrentTimestamp extends Number {
-  validate() { this == now }
+  // Fix me (can be bad): <= is only made to make targaryen tests work
+  // see https://github.com/goldibex/targaryen/issues/29
+  validate() { this <= now }
 }
 
 type ShortString extends String {
@@ -60,6 +63,21 @@ type UserPresence {
   user: User
 }
 
+type Room {
+  name: ShortRequiredString,
+  createdAt: CurrentTimestamp
+}
+
+type RoomMemberShip {
+  joinedAt: CurrentTimestamp
+}
+
+type RoomMessage {
+  user: User,
+  message: ExtraLongRequiredString,
+  sentAt:  CurrentTimestamp
+}
+
 // Paths
 
 path /hello-world is HelloWorld {
@@ -87,4 +105,30 @@ path /users-presence/{uid} is UserPresence[] {
   create() { isViewer(uid) }
   update() { true }
   delete() { true }
+}
+
+path /rooms {
+  read() { true }
+}
+
+path /rooms/{room_id} is Room {
+  create() { isSignedIn() }
+}
+
+path /rooms-members/{room_id} {
+  read() { true }
+}
+
+path /rooms-members/{room_id}/{uid} is RoomMemberShip {
+  create() { isViewer(uid) }
+  delete() { isViewer(uid) }
+}
+
+path /rooms-messages/{room_id} {
+  read() { isRoomMember(room_id) }
+}
+
+path /rooms-messages/{room_id}/{message_id} is RoomMessage {
+  // Todo: check if room exist
+  create() { isRoomMember(room_id) }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "ava": {
     "babel": "inherit",
     "files": [
-      "src/**/__test__/**/*.js"
+      "src/**/__test__/**/*.js",
+      "firebase/__test__/**/*.js"
     ],
     "source": [
       "src/**/*"
@@ -47,6 +48,7 @@
     "babel-register": "^6.3.13",
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.0.5",
+    "chai": "^3.5.0",
     "chroma-js": "^1.2.1",
     "classnames": "^2.1.1",
     "compression": "^1.4.0",
@@ -67,6 +69,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "firebase": "^3.1.0",
+    "firebase-bolt": "^0.8.1",
     "flow-bin": "0.30.0",
     "gravatar-api": "^1.4.0",
     "gulp": "^3.9.0",
@@ -122,6 +125,7 @@
     "sinon": "^1.17.2",
     "sinon-as-promised": "^4.0.0",
     "style-loader": "^0.13.0",
+    "targaryen": "^2.2.0",
     "through2": "^2.0.1",
     "transit-immutable-js": "^0.6.0",
     "transit-js": "^0.8.846",

--- a/src/browser/app/Header.js
+++ b/src/browser/app/Header.js
@@ -21,6 +21,10 @@ const Header = ({ viewer }) => (
       <FormattedMessage {...linksMessages.firebase} />
     </Link>
     <Space x={2} />
+    <Link bold inverted to="/chatx">
+      <FormattedMessage {...linksMessages.chatx} />
+    </Link>
+    <Space x={2} />
     <Link bold inverted to="/todos">
       <FormattedMessage {...linksMessages.todos} />
     </Link>

--- a/src/browser/chatx/ChatRoom.js
+++ b/src/browser/chatx/ChatRoom.js
@@ -49,6 +49,9 @@ ChatRoom.propTypes = {
 ChatRoom = queryFirebase(ChatRoom, ({ roomId, onMessagesReceived }) => ({
   path: `rooms-messages/${roomId}`,
   on: { value: snap => onMessagesReceived(roomId, snap.val()) },
+  params: [
+    ['limitToFirst', 10],
+  ],
 }));
 
 

--- a/src/browser/chatx/ChatRoom.js
+++ b/src/browser/chatx/ChatRoom.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import Message from './Message';
+import MessageBox from './MessageBox';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import {
+  Card,
+  Box,
+  Block,
+  Heading,
+  Divider,
+} from '../app/components';
+import { queryFirebase } from '../../common/lib/redux-firebase';
+import { processReceivedMessages, sendMessage } from '../../common/chatx/actions';
+
+let ChatRoom = ({ room, me, messages, onNewMessage }) => {
+  const onMessageSubmit = text => onNewMessage(room.id, me, text);
+  const memberNames = room.members.map(m => m.get('displayName'));
+  return (
+    <Card p={0}>
+      <Box px={2} py={2}>
+        <Heading level={3} children={room.get('name')} />
+        { room.members.size === 0 ?
+          <Heading level={6} children="You are alone in this room :(" />
+        :
+          <Heading level={6} children={`with: ${memberNames.join(', ')}`} />
+        }
+      </Box>
+      {messages.valueSeq().map((message, i) =>
+        <Block p={2} borderLeft key={i}>
+          <Message message={message} />
+        </Block>
+      )}
+      <Divider my={0} />
+      <Box px={2} py={2}>
+        <MessageBox onNewMessage={onMessageSubmit} />
+      </Box>
+    </Card>
+  );
+};
+
+ChatRoom.propTypes = {
+  room: React.PropTypes.object.isRequired,
+  messages: React.PropTypes.object.isRequired,
+  me: React.PropTypes.object.isRequired,
+  onNewMessage: React.PropTypes.func.isRequired,
+};
+
+ChatRoom = queryFirebase(ChatRoom, ({ roomId, onMessagesReceived }) => ({
+  path: `rooms-messages/${roomId}`,
+  on: { value: snap => onMessagesReceived(roomId, snap.val()) },
+}));
+
+
+const mapStateToProps = (state, { roomId }) => {
+
+  // could also use reselect
+  const messages = state.chatx.messages.filter(v => v.get('roomId') === roomId);
+
+  return {
+    room: state.chatx.rooms.get(roomId),
+    messages,
+    me: state.users.viewer,
+  };
+};
+
+const mapDispatchToProps = (dispatch, { roomId, me }) => ({
+  onNewMessage: bindActionCreators(sendMessage, dispatch),
+  onMessagesReceived: bindActionCreators(processReceivedMessages, dispatch),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ChatRoom);

--- a/src/browser/chatx/ChatXPage.js
+++ b/src/browser/chatx/ChatXPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import {
   Title,
   View,
@@ -6,42 +6,55 @@ import {
   Flex,
   Card,
   Box,
-  Block,
-  Heading,
   Divider,
 } from '../app/components';
 import { injectIntl, intlShape } from 'react-intl';
 import Rooms from './Rooms';
 import NewRoom from './NewRoom';
 import ChatRoom from './ChatRoom';
-import Message from './Message';
-import MessageBox from './MessageBox'
 import { connect } from 'react-redux';
 
-let ChatXPage = ({ canLoadChat }) => (
+let ChatXPage = ({ canLoadChat, openedRoomId }) => (
   <View>
     <Title message="ChatX" />
     <PageHeader heading="A Chat" />
-    <Flex align="flex-start" justify="space-between">
-      <Box col={3}>
-        <Card mr={1}>
-          <Box px={2} py={2}>
-            <Rooms />
-          </Box>
-          <Divider my={0} />
-          <Box px={2} py={2}>
-            <NewRoom />
-          </Box>
-        </Card>
-      </Box>
-      <Box auto>
-      </Box>
-    </Flex>
+    {canLoadChat ?
+      <Flex align="flex-start" justify="space-between">
+        <Box col={3}>
+          <Card mr={1}>
+            <Box px={2} py={2}>
+              <Rooms />
+            </Box>
+            <Divider my={0} />
+            <Box px={2} py={2}>
+              <NewRoom />
+            </Box>
+          </Card>
+        </Box>
+        <Box auto>
+          {openedRoomId ?
+            <ChatRoom roomId={openedRoomId} />
+            :
+            <div> Please Open a Rooom</div>
+          }
+
+        </Box>
+      </Flex>
+    :
+      <div> Please log in before </div>
+  }
   </View>
 );
 
 ChatXPage.propTypes = {
   intl: intlShape,
+  canLoadChat: PropTypes.bool.isRequired,
+  openedRoomId: PropTypes.string.isRequired
 };
+
+ChatXPage = connect(state => ({
+  canLoadChat: !!state.users.viewer && !!state.chatx.rooms && (state.chatx.rooms.size > 0),
+  openedRoomId: state.chatx.openedRoomId,
+}))(ChatXPage);
 
 export default injectIntl(ChatXPage);

--- a/src/browser/chatx/ChatXPage.js
+++ b/src/browser/chatx/ChatXPage.js
@@ -22,6 +22,21 @@ let ChatXPage = ({ canLoadChat }) => (
   <View>
     <Title message="ChatX" />
     <PageHeader heading="A Chat" />
+    <Flex align="flex-start" justify="space-between">
+      <Box col={3}>
+        <Card mr={1}>
+          <Box px={2} py={2}>
+            <Rooms />
+          </Box>
+          <Divider my={0} />
+          <Box px={2} py={2}>
+            <NewRoom />
+          </Box>
+        </Card>
+      </Box>
+      <Box auto>
+      </Box>
+    </Flex>
   </View>
 );
 

--- a/src/browser/chatx/ChatXPage.js
+++ b/src/browser/chatx/ChatXPage.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+  Title,
+  View,
+  PageHeader,
+  Flex,
+  Card,
+  Box,
+  Block,
+  Heading,
+  Divider,
+} from '../app/components';
+import { injectIntl, intlShape } from 'react-intl';
+import Rooms from './Rooms';
+import NewRoom from './NewRoom';
+import ChatRoom from './ChatRoom';
+import Message from './Message';
+import MessageBox from './MessageBox'
+import { connect } from 'react-redux';
+
+let ChatXPage = ({ canLoadChat }) => (
+  <View>
+    <Title message="ChatX" />
+    <PageHeader heading="A Chat" />
+  </View>
+);
+
+ChatXPage.propTypes = {
+  intl: intlShape,
+};
+
+export default injectIntl(ChatXPage);

--- a/src/browser/chatx/Message.js
+++ b/src/browser/chatx/Message.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import Gravatar from 'react-gravatar';
+import {
+  Avatar,
+  Text,
+  Flex,
+  Box,
+} from '../app/components';
+
+
+const Message = ({ message }) => {
+  const user = message.get('user');
+  return (
+    <Flex align="center">
+      <Box>
+        {user.get('photoURL') ?
+          <Avatar mr={2} src={user.get('photoURL')} title={user.get('displayName')} />
+          :
+          <Gravatar
+            default="retro"
+            style={{ 'margin-right': '4px' }}
+            email={user.get('displayName')} // For users signed in via email.
+            https
+            rating="x"
+            title={user.get('displayName')}
+          />
+        }
+      </Box>
+      <Box>
+        <Text
+          small
+          bold
+          color="midgray"
+          children={user.get('displayName')}
+        />
+        <Text children={message.get('text')} />
+      </Box>
+    </Flex>
+  );
+};
+
+Message.propTypes = {
+  message: React.PropTypes.object.isRequired,
+};
+
+export default Message;

--- a/src/browser/chatx/MessageBox.js
+++ b/src/browser/chatx/MessageBox.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fields } from '../../common/lib/redux-fields';
+import {
+  ButtonOutline,
+  Input,
+  Form,
+  Flex,
+  Box,
+} from '../app/components';
+
+
+const MessageBox = ({ onNewMessage, fields }) => {
+  const onSubmit = () => {
+    if (!fields.newMessage.value.trim()) return;
+    onNewMessage(fields.newMessage.value);
+    fields.$reset();
+  };
+
+  return (
+    <Flex>
+      <Form onSubmit={onSubmit}>
+        <Box auto>
+          <Input
+            {...fields.newMessage}
+            label="new_message"
+            placeholder="Send message.."
+            hideLabel
+            mb={0}
+            rounded="left"
+          />
+        </Box>
+        <ButtonOutline
+          type="submit"
+          rounded="right"
+          children="Send"
+        />
+      </Form>
+    </Flex>
+  );
+};
+
+MessageBox.propTypes = {
+  onNewMessage: React.PropTypes.func.isRequired,
+  fields: React.PropTypes.object.isRequired,
+};
+
+export default fields(MessageBox, {
+  path: 'chatx.newMessage',
+  fields: ['newMessage'],
+});

--- a/src/browser/chatx/NewRoom.js
+++ b/src/browser/chatx/NewRoom.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { createRoom } from '../../common/chatx/actions';
+import { fields } from '../../common/lib/redux-fields';
+import { Button, Input, Form } from '../app/components';
+
+
+let NewRoom = ({ createRoom, fields }) => {
+  const onSubmit = () => {
+    if (!fields.roomName.value.trim()) return;
+    createRoom(fields.roomName.value);
+    fields.$reset();
+  };
+  return (
+    <Form small onSubmit={onSubmit}>
+      <Input
+        {...fields.roomName}
+        label=""
+        placeholder="new room name.."
+      />
+    <Button type="submit" >Create</Button>
+    </Form>
+  );
+};
+
+
+NewRoom.propTypes = {
+  createRoom: React.PropTypes.func.isRequired,
+  fields: React.PropTypes.object.isRequired,
+};
+
+NewRoom = fields(NewRoom, {
+  path: 'chatx.newRoom',
+  fields: ['roomName'],
+});
+
+export default connect(null, { createRoom })(NewRoom);

--- a/src/browser/chatx/Room.js
+++ b/src/browser/chatx/Room.js
@@ -1,0 +1,26 @@
+import React, { PropTypes } from 'react';
+import { Flex, Heading, Space, Tooltip, Badge } from '../app/components';
+
+const Room = ({ room }) => {
+  return (
+    <Flex>
+      <Heading level={5}> {room.name}
+        <Space x={1} />
+          <Badge
+            circle
+            rounded
+            theme="primary"
+          >
+            {room.members.size}
+          </Badge>
+      </Heading>
+    </Flex>
+  );
+};
+
+
+Room.propTypes = {
+  room: PropTypes.object.isRequired,
+};
+
+export default Room;

--- a/src/browser/chatx/Room.js
+++ b/src/browser/chatx/Room.js
@@ -1,19 +1,26 @@
 import React, { PropTypes } from 'react';
-import { Flex, Heading, Space, Tooltip, Badge } from '../app/components';
+import { Flex, Space, Badge, Button, Text } from '../app/components';
 
-const Room = ({ room }) => {
+const Room = ({ room, onJoinClicked }) => {
   return (
-    <Flex>
-      <Heading level={5}> {room.name}
-        <Space x={1} />
-          <Badge
-            circle
-            rounded
-            theme="primary"
-          >
-            {room.members.size}
-          </Badge>
-      </Heading>
+    <Flex align="baseline">
+      <Text children={room.name} />
+      <Space x={1} />
+      <Badge
+        circle
+        rounded
+        theme="primary"
+      >
+        {room.members.size}
+      </Badge>
+      <Space auto />
+      { room.joined ?
+        <Button theme="secondary" disabled>joined</Button>
+        :
+        <Button theme="primary" onClick={onJoinClicked}>
+          join
+        </Button>
+      }
     </Flex>
   );
 };
@@ -21,6 +28,7 @@ const Room = ({ room }) => {
 
 Room.propTypes = {
   room: PropTypes.object.isRequired,
+  onJoinClicked: PropTypes.func.isRequired,
 };
 
 export default Room;

--- a/src/browser/chatx/Room.js
+++ b/src/browser/chatx/Room.js
@@ -1,10 +1,12 @@
 import React, { PropTypes } from 'react';
-import { Flex, Space, Badge, Button, Text } from '../app/components';
+import { Flex, Space, Badge, Button, Text, LinkBlock } from '../app/components';
 
-const Room = ({ room, onJoinClicked }) => {
+const Room = ({ room, onJoinClicked, onOpenClicked }) => {
   return (
     <Flex align="baseline">
-      <Text children={room.name} />
+      <LinkBlock is='a' href="javascript:void(0);" onClick={onOpenClicked}>
+        <Text children={room.name} />
+      </LinkBlock>
       <Space x={1} />
       <Badge
         circle
@@ -29,6 +31,7 @@ const Room = ({ room, onJoinClicked }) => {
 Room.propTypes = {
   room: PropTypes.object.isRequired,
   onJoinClicked: PropTypes.func.isRequired,
+  onOpenClicked: PropTypes.func.isRequired,
 };
 
 export default Room;

--- a/src/browser/chatx/Rooms.js
+++ b/src/browser/chatx/Rooms.js
@@ -1,21 +1,49 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { joinRoom } from '../../common/chatx/actions';
 import Room from './Room';
-import { View } from '../app/components';
+import { View, Divider } from '../app/components';
+import { bindActionCreators } from 'redux';
 
-const Rooms = (props) => {
-  const rooms = props.rooms;
+
+const Rooms = ( {rooms, myuid, onRoomJoin} ) => {
   return (
     <View>
-      {rooms.valueSeq().map(room => <Room key={room.id} room={room} />)}
+      {rooms.valueSeq().map((room, i) => {
+        return (
+          <div key={room.id}>
+            <Room
+              room={room}
+              onJoinClicked={() => onRoomJoin(myuid, room.id)}
+            />
+            { i !== rooms.size - 1 ? <Divider /> : ''}
+          </div>
+        );
+      }
+    )}
     </View>
   );
 };
 
 Rooms.propTypes = {
   rooms: PropTypes.object.isRequired,
+  onRoomJoin: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => ({ rooms: state.chatx.rooms });
+const mapStateToProps = (state) => {
+  let rooms = state.chatx.rooms;
+  const myuid = state.users.viewer.id;
 
-export default connect(mapStateToProps)(Rooms);
+  rooms = rooms.map(r => r.set('joined', r.members.has(myuid)));
+  return {
+    rooms,
+    myuid,
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  onRoomJoin: bindActionCreators(joinRoom, dispatch),
+});
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(Rooms);

--- a/src/browser/chatx/Rooms.js
+++ b/src/browser/chatx/Rooms.js
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import Room from './Room';
+import { View } from '../app/components';
+
+const Rooms = (props) => {
+  const rooms = props.rooms;
+  return (
+    <View>
+      {rooms.valueSeq().map(room => <Room key={room.id} room={room} />)}
+    </View>
+  );
+};
+
+Rooms.propTypes = {
+  rooms: PropTypes.object.isRequired,
+};
+
+const mapStateToProps = state => ({ rooms: state.chatx.rooms });
+
+export default connect(mapStateToProps)(Rooms);

--- a/src/browser/chatx/Rooms.js
+++ b/src/browser/chatx/Rooms.js
@@ -1,12 +1,12 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { joinRoom } from '../../common/chatx/actions';
+import { joinRoom, openRoom } from '../../common/chatx/actions';
 import Room from './Room';
 import { View, Divider } from '../app/components';
 import { bindActionCreators } from 'redux';
 
 
-const Rooms = ( {rooms, myuid, onRoomJoin} ) => {
+const Rooms = ( {rooms, myuid, onRoomJoin, onRoomOpen} ) => {
   return (
     <View>
       {rooms.valueSeq().map((room, i) => {
@@ -15,6 +15,7 @@ const Rooms = ( {rooms, myuid, onRoomJoin} ) => {
             <Room
               room={room}
               onJoinClicked={() => onRoomJoin(myuid, room.id)}
+              onOpenClicked={() => onRoomOpen(room.id)}
             />
             { i !== rooms.size - 1 ? <Divider /> : ''}
           </div>
@@ -28,6 +29,7 @@ const Rooms = ( {rooms, myuid, onRoomJoin} ) => {
 Rooms.propTypes = {
   rooms: PropTypes.object.isRequired,
   onRoomJoin: PropTypes.func.isRequired,
+  onRoomOpen: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => {
@@ -37,12 +39,13 @@ const mapStateToProps = (state) => {
   rooms = rooms.map(r => r.set('joined', r.members.has(myuid)));
   return {
     rooms,
-    myuid,
+    myuid
   };
 };
 
 const mapDispatchToProps = dispatch => ({
   onRoomJoin: bindActionCreators(joinRoom, dispatch),
+  onRoomOpen: bindActionCreators(openRoom, dispatch),
 });
 
 

--- a/src/browser/createRoutes.js
+++ b/src/browser/createRoutes.js
@@ -14,6 +14,7 @@ import Profile from './me/ProfilePage';
 import Settings from './me/SettingsPage';
 import SignIn from './auth/SignInPage';
 import Todos from './todos/TodosPage';
+import ChatX from './chatx/ChatXPage';
 
 const createRoutes = (getState: Function) => {
   const requireViewer = (nextState, replace) => {
@@ -28,6 +29,7 @@ const createRoutes = (getState: Function) => {
     <Route component={App} path="/">
       <IndexRoute component={Home} />
       <Route component={Fields} path="fields" />
+      <Route component={ChatX} path="chatx" />
       <Route component={Firebase} path="firebase" />
       <Route component={Intl} path="intl" />
       <Route component={Me} onEnter={requireViewer} path="me">

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -11,15 +11,15 @@ import { fromJSON } from '../common/transit';
 import { routerMiddleware, syncHistoryWithStore } from 'react-router-redux';
 
 const initialState = fromJSON(window.__INITIAL_STATE__); // eslint-disable-line no-underscore-dangle
-const reportingMiddleware = configureReporting({
-  appVersion: initialState.config.appVersion,
-  sentryUrl: initialState.config.sentryUrl,
-  unhandledRejection: fn => window.addEventListener('unhandledrejection', fn),
-});
+// const reportingMiddleware = configureReporting({
+//   appVersion: initialState.config.appVersion,
+//   sentryUrl: initialState.config.sentryUrl,
+//   unhandledRejection: fn => window.addEventListener('unhandledrejection', fn),
+// });
 const store = configureStore({
   initialState,
   platformDeps: { createStorageEngine, uuid },
-  platformMiddleware: [reportingMiddleware, routerMiddleware(browserHistory)],
+  platformMiddleware: [/*reportingMiddleware, */routerMiddleware(browserHistory)],
 });
 const history = syncHistoryWithStore(browserHistory, store);
 const appElement = document.getElementById('app');

--- a/src/common/app/actions.js
+++ b/src/common/app/actions.js
@@ -1,5 +1,6 @@
 /* @flow weak */
 import { firebaseStart } from '../lib/redux-firebase/actions';
+import { chatXStart } from '../chatx/actions';
 
 export const APP_OFFLINE = 'APP_OFFLINE';
 export const APP_ONLINE = 'APP_ONLINE';
@@ -21,6 +22,7 @@ export const start = () => {
     loadStorage(dispatch, storageEngine).finally(() => {
       dispatch(firebaseStart());
     });
+    dispatch(chatXStart());
     return {
       type: APP_START,
     };

--- a/src/common/app/linksMessages.js
+++ b/src/common/app/linksMessages.js
@@ -46,6 +46,10 @@ const LinkMessages = defineMessages({
     defaultMessage: 'Todos',
     id: 'app.links.todos',
   },
+  chatx: {
+    defaultMessage: 'ChatX',
+    id: 'app.links.chatx',
+  },
 });
 
 export default LinkMessages;

--- a/src/common/chatx/actions/index.js
+++ b/src/common/chatx/actions/index.js
@@ -17,3 +17,8 @@ export {
 } from './rooms';
 
 
+export {
+  processReceivedMessages,
+  sendMessage,
+  ON_MESSAGES_VALUE,
+} from './messages';

--- a/src/common/chatx/actions/index.js
+++ b/src/common/chatx/actions/index.js
@@ -12,6 +12,7 @@ export const chatXStart = () => ({ firebase, dispatch }) => {
 
 export {
   createRoom,
+  joinRoom,
   ON_ROOMS_VALUE,
   ON_ROOM_MEMBER_VALUE,
 } from './rooms';

--- a/src/common/chatx/actions/index.js
+++ b/src/common/chatx/actions/index.js
@@ -1,0 +1,19 @@
+import { startListeningToRooms } from './rooms';
+import ChatXMonitor from '../lib/ChatXMonitor'
+
+export const chatXStart = () => ({ firebase, dispatch }) => {
+  const monitor = new ChatXMonitor(firebase, 'foo');
+  dispatch(startListeningToRooms(monitor));
+  monitor.start();
+  return {
+    type: 'CHATX_START',
+  };
+};
+
+export {
+  createRoom,
+  ON_ROOMS_VALUE,
+  ON_ROOM_MEMBER_VALUE,
+} from './rooms';
+
+

--- a/src/common/chatx/actions/index.js
+++ b/src/common/chatx/actions/index.js
@@ -13,8 +13,10 @@ export const chatXStart = () => ({ firebase, dispatch }) => {
 export {
   createRoom,
   joinRoom,
+  openRoom,
   ON_ROOMS_VALUE,
   ON_ROOM_MEMBER_VALUE,
+  ON_ROOM_OPEN,
 } from './rooms';
 
 

--- a/src/common/chatx/actions/messages.js
+++ b/src/common/chatx/actions/messages.js
@@ -1,0 +1,29 @@
+import { database } from 'firebase';
+
+export const ON_MESSAGES_VALUE = 'ON_MESSAGES_VALUE';
+export const ON_NEW_MESSAGE = 'ON_NEW_MESSAGE';
+
+
+export const processReceivedMessages = (roomId, messages) => ({
+  type: ON_MESSAGES_VALUE,
+  payload: { roomId, messages },
+});
+
+
+export const sendMessage = (roomId, me, text) => ({ firebase, dispatch }) => {
+  const ref = firebase.child(`rooms-messages/${roomId}`);
+  const message = {
+    text,
+    sentAt: database.ServerValue.TIMESTAMP,
+    user: {
+      id: me.id,
+      displayName: me.displayName,
+      photoURL: me.photoURL,
+    },
+  };
+  ref.push(message, () => dispatch({ type: 'MESSAGE_SENT', payload: message }));
+  return {
+    type: 'MESSAGE_SEND_REQUEST',
+    payload: message,
+  };
+};

--- a/src/common/chatx/actions/rooms.js
+++ b/src/common/chatx/actions/rooms.js
@@ -1,0 +1,38 @@
+import { database } from 'firebase';
+
+export const ON_ROOMS_VALUE = 'ON_ROOMS_VALUE';
+export const ON_ROOM_MEMBER_VALUE = 'ON_ROOM_MEMBER_VALUE';
+export const ROOMS_LISTENING_START = 'ROOMS_LISTENING_START';
+
+export const startListeningToRooms = engine => ({ dispatch }) => {
+  engine.on('rooms', (rooms) => {
+    dispatch({
+      type: ON_ROOMS_VALUE,
+      payload: rooms,
+    });
+  });
+
+  engine.on('room-members', (data) => {
+    dispatch({
+      type: ON_ROOM_MEMBER_VALUE,
+      payload: data,
+    });
+  });
+
+  return {
+    type: ROOMS_LISTENING_START,
+  };
+};
+
+
+export const createRoom = roomName => ({ firebase, dispatch }) => {
+  firebase.child('rooms').push({
+    name: roomName,
+    createdAt: database.ServerValue.TIMESTAMP,
+  }, () => {
+    dispatch({ type: 'ROOM_ADDED' });
+  });
+  return {
+    type: 'ADD_ROOM_REQUEST',
+  };
+};

--- a/src/common/chatx/actions/rooms.js
+++ b/src/common/chatx/actions/rooms.js
@@ -36,3 +36,14 @@ export const createRoom = roomName => ({ firebase, dispatch }) => {
     type: 'ADD_ROOM_REQUEST',
   };
 };
+
+export const joinRoom = (myuid, roomId) => ({ firebase, dispatch }) => {
+  firebase
+    .child(`rooms-members/${roomId}/${myuid}`)
+    .set({ joinedAt: database.ServerValue.TIMESTAMP })
+    .then(() => dispatch({ type: 'JOINED_ROOM' }));
+  return {
+    type: 'JOIN_ROOM_REQUEST',
+    payload: { myuid, roomId },
+  };
+};

--- a/src/common/chatx/actions/rooms.js
+++ b/src/common/chatx/actions/rooms.js
@@ -3,6 +3,7 @@ import { database } from 'firebase';
 export const ON_ROOMS_VALUE = 'ON_ROOMS_VALUE';
 export const ON_ROOM_MEMBER_VALUE = 'ON_ROOM_MEMBER_VALUE';
 export const ROOMS_LISTENING_START = 'ROOMS_LISTENING_START';
+export const ON_ROOM_OPEN = 'ON_ROOM_OPEN';
 
 export const startListeningToRooms = engine => ({ dispatch }) => {
   engine.on('rooms', (rooms) => {
@@ -47,3 +48,5 @@ export const joinRoom = (myuid, roomId) => ({ firebase, dispatch }) => {
     payload: { myuid, roomId },
   };
 };
+
+export const openRoom = roomId => ({ type: ON_ROOM_OPEN, payload: roomId });

--- a/src/common/chatx/lib/ChatXMonitor.js
+++ b/src/common/chatx/lib/ChatXMonitor.js
@@ -1,0 +1,60 @@
+/* eslint-disable no-underscore-dangle */
+
+import { EventEmitter } from 'events';
+import Promise from 'bluebird';
+
+class ChatXMonitor extends EventEmitter {
+
+  constructor(fiebase, uid) {
+    super();
+    this.firebase = fiebase;
+    this.uid = uid;
+
+    this._roomsMembersListening = {};
+  }
+
+  _startListeningToRooms() {
+    const ref = this.firebase.child('rooms');
+    ref.on('value', (snap) => {
+      const rooms = snap.val();
+      this.emit('rooms', rooms);
+
+      const roomIds = Object.keys(rooms);
+      roomIds.forEach(roomId => this._startListeningToRoomMembers(roomId));
+    });
+  }
+
+  _startListeningToRoomMembers(roomId) {
+    // we are maybe already listening
+    if (this._roomsMembersListening[roomId]) return;
+
+    const ref = this.firebase.child(`rooms-members/${roomId}`);
+    ref.on('value', (snap) => {
+      const members = snap.val() || [];
+
+      // join users info
+      Promise
+      .map(Object.keys(members), uid =>
+           Promise.props({
+             uid,
+             snap: this.firebase.child(`users/${uid}`).once('value'),
+           })
+        ).then((members) => {
+          members = members.reduce((dict, { uid, snap }) => {
+            dict[uid] = snap.val();
+            return dict;
+          }, {});
+          this.emit('room-members', { roomId, members });
+        });
+    });
+
+    this._roomsMembersListening[roomId] = true;
+  }
+
+  start() {
+    this._startListeningToRooms();
+  }
+
+}
+
+export default ChatXMonitor;

--- a/src/common/chatx/reducers/index.js
+++ b/src/common/chatx/reducers/index.js
@@ -1,0 +1,3 @@
+import { combineReducers } from 'redux';
+export default combineReducers({
+});

--- a/src/common/chatx/reducers/index.js
+++ b/src/common/chatx/reducers/index.js
@@ -1,5 +1,8 @@
 import { combineReducers } from 'redux';
 import roomsReducer from './rooms';
+import messageReducer from './messages';
+
 export default combineReducers({
   rooms: roomsReducer,
+  messages: messageReducer,
 });

--- a/src/common/chatx/reducers/index.js
+++ b/src/common/chatx/reducers/index.js
@@ -1,8 +1,18 @@
 import { combineReducers } from 'redux';
 import roomsReducer from './rooms';
 import messageReducer from './messages';
+import * as actions from '../actions';
 
 export default combineReducers({
   rooms: roomsReducer,
   messages: messageReducer,
+  openedRoomId: (state = null, action) => {
+    switch (action.type) {
+      case actions.ON_ROOM_OPEN: {
+        return action.payload;
+      }
+      default:
+        return state;
+    }
+  },
 });

--- a/src/common/chatx/reducers/index.js
+++ b/src/common/chatx/reducers/index.js
@@ -1,3 +1,5 @@
 import { combineReducers } from 'redux';
+import roomsReducer from './rooms';
 export default combineReducers({
+  rooms: roomsReducer,
 });

--- a/src/common/chatx/reducers/messages.js
+++ b/src/common/chatx/reducers/messages.js
@@ -7,6 +7,8 @@ export default (state = new Map(), action) => {
     case actions.ON_MESSAGES_VALUE: {
       const { roomId, messages } = action.payload;
 
+      if (!messages) return state;
+
       const newMessages =
       Object.keys(messages)
         .map((messageId) => {

--- a/src/common/chatx/reducers/messages.js
+++ b/src/common/chatx/reducers/messages.js
@@ -1,0 +1,26 @@
+import { Map, fromJS } from 'immutable';
+import * as actions from '../actions';
+
+
+export default (state = new Map(), action) => {
+  switch (action.type) {
+    case actions.ON_MESSAGES_VALUE: {
+      const { roomId, messages } = action.payload;
+
+      const newMessages =
+      Object.keys(messages)
+        .map((messageId) => {
+          const message = messages[messageId];
+          message.id = messageId;
+          message.roomId = roomId;
+          return fromJS(message);
+        })
+        .reduce((messages, message) => messages.set(message.get('id'), message), new Map());
+
+      return state.merge(newMessages);
+    }
+
+    default:
+      return state;
+  }
+};

--- a/src/common/chatx/reducers/rooms.js
+++ b/src/common/chatx/reducers/rooms.js
@@ -6,6 +6,7 @@ const Room = Record({
   name: null,
   id: null,
   members: Map(),
+  joined: null,
 }, 'room');
 
 

--- a/src/common/chatx/reducers/rooms.js
+++ b/src/common/chatx/reducers/rooms.js
@@ -1,0 +1,47 @@
+import { Map, fromJS } from 'immutable';
+import * as actions from '../actions';
+import { Record } from '../../transit';
+
+const Room = Record({
+  name: null,
+  id: null,
+  members: Map(),
+}, 'room');
+
+
+const roomsReducer = (state = new Map(), action) => {
+  switch (action.type) {
+
+    case actions.ON_ROOMS_VALUE: {
+      const rooms = action.payload;
+      const newRooms =
+      Object.keys(rooms)
+        .map((roomId) => {
+          const room = rooms[roomId];
+          room.id = roomId;
+          room.members = state.getIn([roomId, 'members']) || new Map();
+          return new Room(room);
+        })
+        .reduce((rooms, room) => rooms.set(room.id, room), new Map());
+
+      return state.merge(newRooms);
+    }
+
+    case actions.ON_ROOM_MEMBER_VALUE: {
+      const { roomId, members } = action.payload;
+
+      let newMembers = Map();
+      if (members) {
+        newMembers = Object.keys(members)
+        .reduce((map, userId) => map.set(userId, fromJS(members[userId])), new Map());
+      }
+
+      return state.setIn([roomId, 'members'], newMembers);
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default roomsReducer;

--- a/src/common/configureReducer.js
+++ b/src/common/configureReducer.js
@@ -8,6 +8,7 @@ import nativeRouting from '../native/routing/reducer';
 import themes from './themes/reducer';
 import todos from './todos/reducer';
 import users from './users/reducer';
+import chatx from './chatx/reducers';
 import { FIREBASE_ON_AUTH } from '../common/lib/redux-firebase/actions';
 import { combineReducers } from 'redux';
 import { fieldsReducer as fields } from './lib/redux-fields';
@@ -51,6 +52,7 @@ const configureReducer = (initialState: Object) => {
     themes,
     todos,
     users,
+    chatx,
   });
 
   // The power of higher-order reducers, http://slides.com/omnidan/hor

--- a/src/common/configureStore.js
+++ b/src/common/configureStore.js
@@ -1,7 +1,8 @@
 /* @flow */
+/* eslint-env browser*/
 import configureReducer from './configureReducer';
 import configureMiddleware from './configureMiddleware';
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
 
 type Options = {
   initialState: Object,
@@ -24,10 +25,19 @@ const configureStore = (options: Options) => {
     platformMiddleware
   );
 
+  let devTools = f => f;
+  if (typeof window === 'object') {
+    if (typeof window.devToolsExtension !== 'undefined') {
+      devTools = window.devToolsExtension();
+    }
+  }
   const store = createStore(
     reducer,
     initialState,
-    applyMiddleware(...middleware)
+    compose(
+      applyMiddleware(...middleware),
+      devTools
+    )
   );
 
   // Enable hot reloading for reducers.

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -17,10 +17,10 @@ nconf.defaults({
   defaultLocale: 'en',
   firebase: {
     // To get the config, just click Add web app from the overview page.
-    apiKey: 'AIzaSyDZRAOrDErAaC-TCKbr4cMzaohsPR4sWgU',
-    authDomain: 'este.firebaseapp.com',
-    databaseURL: 'https://este.firebaseio.com',
-    storageBucket: 'project-808488257248094054.appspot.com',
+    apiKey: 'AIzaSyCBXvbbLuoudj63oquUhT8Il30oUQHxvGM',
+    authDomain: 'este-efounders-test.firebaseapp.com',
+    databaseURL: 'https://este-efounders-test.firebaseio.com',
+    storageBucket: 'este-efounders-test.appspot.com',
   },
   googleAnalyticsId: 'UA-XXXXXXX-X',
   isProduction: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
To do:
- [ ] add unit testing
- [ ] add i18n
- [ ] replace `ChatXMonitor` thing with `queryFirebase` wrapped components all over the place
- [ ] fix clumsy navigation between rooms
- [ ] add loading states
- [ ] add native and server side (?) implementations
- [ ] check auth status with viewer (_uh? what did i mean here_)
- [ ] add `users-rooms` collection in firebase for convenience (despite [redundancy](https://www.firebase.com/docs/web/guide/structuring-data.html))
- [ ] improve room joining and creation UX inspired by Slack

is it redux friendly?
